### PR TITLE
Add requirement for ctype extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "issues": "https://github.com/oscarotero/env/issues"
     },
     "require": {
-        "php": ">=5.2"
+        "php": ">=5.2",
+        "ext-ctype": "*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Some minimal systems like alpine docker containers don't necessarily have `ctype_*` functions available by default. By adding `ext-ctype` to requirements composer can give clear and verbose error when installing this library.

Heroku says it's best practise to use `*` as version requirement for extensions:
> It is recommended that you use “*” as the version selector when specifying extensions that are bundled with PHP, as their version numbers can be highly inconsistent (they often report their version as “0”).
> source: https://devcenter.heroku.com/articles/php-support