### PR TITLE
Add namespace `Env`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,20 @@
 language: php
 sudo: false
-matrix:
-  include:
-    - php: 5.2
-      dist: precise
-    - php: 5.3
-      dist: precise
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
+  - nightly
+
+jobs:
+  allow_failures:
+    - php: nightly
+
+install:
+  - composer install --no-interaction --prefer-dist
 
 script:
-  - phpunit
+  - composer test

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ composer require oscarotero/env
 var_dump(getenv('FOO')); //string(5) "false"
 
 // Using Env:
-var_dump(Env::get('FOO')); //bool(false)
+var_dump(\Env\Env::get('FOO')); //bool(false)
 ```
 
 ## Available conversions
@@ -49,6 +49,8 @@ There's also additional settings that you can enable (they're disabled by defaul
 * `Env::LOCAL_FIRST` To get first the values of locally-set environment variables.
 
 ```php
+use Env\Env;
+
 //Convert booleans and null, but not integers or strip quotes
 Env::$options = Env::CONVERT_BOOL | Env::CONVERT_NULL;
 
@@ -64,7 +66,7 @@ Env::$options ^= Env::CONVERT_NULL;
 By default, if the value does not exist, returns `null`, but you can change for any other value:
 
 ```php
-Env::$default = false;
+\Env\Env::$default = false;
 ```
 
 ## The env() function
@@ -72,11 +74,7 @@ Env::$default = false;
 If you don't want to complicate with classes and namespaces, you can use the `env()` function, like in Laravel or other libraries:
 
 ```php
-Env::init(); //expose the function to globals
-
-//now you can use it
-
-var_dump(env('FOO'));
+var_dump(\Env\env('FOO'));
 ```
 
 ---

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,26 @@
         "issues": "https://github.com/oscarotero/env/issues"
     },
     "require": {
-        "php": ">=5.2",
+        "php": ">=5.6",
         "ext-ctype": "*"
     },
     "autoload": {
-        "psr-0": {
-            "Env": "src/"
+        "psr-4": {
+            "Env\\": "src/"
+        },
+        "files": [
+            "src/env_function.php"
+        ]
+    },
+    "config": {
+        "platform": {
+            "php": "5.6.40"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="./tests/bootstrap.php">
+<phpunit>
     <testsuites>
         <testsuite name="All tests">
             <directory>./tests/</directory>

--- a/src/Env.php
+++ b/src/Env.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Env;
+
 class Env
 {
     const CONVERT_BOOL = 1;
@@ -11,23 +13,6 @@ class Env
 
     public static $options = 15;   //All flags enabled
     public static $default = null; //Default value if not exists
-
-    /**
-     * Include the global env() function.
-     * Returns whether the function has been registered or not.
-     * 
-     * @return bool
-     */
-    public static function init()
-    {
-        if (function_exists('env')) {
-            return false;
-        }
-
-        include_once dirname(__FILE__).'/env_function.php';
-
-        return true;
-    }
 
     /**
      * Returns an environment variable.

--- a/src/env_function.php
+++ b/src/env_function.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Env;
+
 /**
  * Gets the value of an environment variable.
  *

--- a/tests/ConversionTest.php
+++ b/tests/ConversionTest.php
@@ -1,8 +1,7 @@
 <?php
 
-if (!class_exists('PHPUnit_Framework_TestCase')) {
-    class_alias('PHPUnit\\Framework\\TestCase', 'PHPUnit_Framework_TestCase');
-}
+use Env\Env;
+use function Env\env;
 
 class ConversionTest extends PHPUnit_Framework_TestCase
 {
@@ -38,13 +37,9 @@ class ConversionTest extends PHPUnit_Framework_TestCase
 
     public function testEnv()
     {
-        $this->assertTrue(Env::init());
-
         putenv('FOO=123');
 
         $this->assertSame(123, env('FOO'));
-
-        $this->assertFalse(Env::init());
 
         //Switch to $_ENV
         Env::$options |= Env::USE_ENV_ARRAY;
@@ -54,10 +49,31 @@ class ConversionTest extends PHPUnit_Framework_TestCase
         $_ENV['FOO'] = 456;
 
         $this->assertSame(456, env('FOO'));
-        
+
         //Switch to getenv again
         Env::$options ^= Env::USE_ENV_ARRAY;
 
         $this->assertSame(123, env('FOO'));
+    }
+
+    public function testEnvGet()
+    {
+        putenv('FOO=123');
+
+        $this->assertSame(123, Env::get('FOO'));
+
+        //Switch to $_ENV
+        Env::$options |= Env::USE_ENV_ARRAY;
+
+        $this->assertNull(Env::get('FOO'));
+
+        $_ENV['FOO'] = 456;
+
+        $this->assertSame(456, Env::get('FOO'));
+        
+        //Switch to getenv again
+        Env::$options ^= Env::USE_ENV_ARRAY;
+
+        $this->assertSame(123, Env::get('FOO'));
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-
-error_reporting(E_ALL);
-
-include_once dirname(dirname(__FILE__)).'/src/Env.php';


### PR DESCRIPTION
Namespace `Env` is added to `composer.json` since the first commit. However, the `Env` class lives under the global namespace.

https://github.com/oscarotero/env/blob/4ab45ce5c1f2c62549208426bfa20a3d5fa008c6/composer.json#L24-L27

Goal: To avoid issues like https://github.com/roots/bedrock/issues/515 and https://github.com/roots/bedrock/pull/516

Note: This is a breaking change.

---

With the namespace, we can autoload [`env_function.php`](https://github.com/oscarotero/env/blob/4ab45ce5c1f2c62549208426bfa20a3d5fa008c6/src/env_function.php) with [composer](https://getcomposer.org/doc/04-schema.md#files) so that we dont need `Env::init()`

---

Using the namespace `OscarOtero\Env` might be a better choice - less chance colliding with other packages.

