### PR TITLE
Fixed implicitly nullable parameter declaration for PHP 8.4

### DIFF
--- a/src/Env.php
+++ b/src/Env.php
@@ -48,7 +48,7 @@ class Env
      *
      * @return mixed
      */
-    public static function convert(string $value, int $options = null)
+    public static function convert(string $value, ?int $options = null)
     {
         if ($options === null) {
             $options = self::$options;


### PR DESCRIPTION
PHP 8.4 [requires](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) explicit nullable parameter declarations, it throws a deprecated exception in other cases.